### PR TITLE
Enhance logging with context properties and add unit tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,82 @@
+
 # Akka.Logger.log4net
 
-This is the log4net integration plugin for Akka.NET. Please check out our [documentation](http://getakka.net/articles/utilities/logging.html) for examples on how to configure your custom logger plugin for usage.
+- This plugin integrates log4net with Akka.NET, and enhances your Akka.NET logging capabilities by integrating with log4net. For detailed usage and configuration examples, see the sections below or explore our [documentation](http://getakka.net/articles/utilities/logging.html).
 
-Currently targetting Log4Net 2.0.8
+- Currently targetting Log4Net 2.0.17
+
+## Using the log4net Logger Integration
+
+With log4net, you can enrich your logs with both custom and automatic context information, such as file names, line numbers, and method names. This makes your logs more informative and easier to trace.
+
+### Obtaining an ILoggerAdapter with Contextual Logging
+
+Use `Log4NetLoggingAdapterExtensions` to get an `ILoggerAdapter` that supports enriched logging:
+
+#### Examples
+
+##### Logging with Automatic Context Information
+
+Simply calling `ForContext` without arguments adds useful context like file name, line number, and method name to your logs:
+
+```csharp
+var logger = Context.GetLogger().ForContext();
+
+logger.Info("This log includes automatic context information.");
+```
+
+##### Logging with Custom Properties
+
+Add custom properties to your logs as follows:
+
+```csharp
+var logger = Context.GetLogger()
+    .ForContext("CustomProperty1", "CustomValue1")
+    .ForContext("CustomProperty2", "CustomValue2");
+
+logger.Info("This log has custom properties.");
+```
+
+Or, use a dictionary for multiple properties (an enumerable of key-value pairs):
+
+```csharp
+var properties = new Dictionary<string, object?>
+{
+    ["UserId"] = "user123",
+    ["Operation"] = "UpdateProfile"
+};
+
+var logger = Context.GetLogger().ForContext(properties);
+logger.Info("User profile updated.");
+```
+
+This will log a message with custom properties `UserId` and `Operation`, along with the source file name, line number, and method name.
+
+
+### Configuring log4net for Custom Properties
+
+To include custom properties in your logs, configure log4net like this:
+
+```xml
+<log4net>
+  <appender name="ConsoleAppender" type="log4net.Appender.ConsoleAppender">
+	<layout type="log4net.Layout.PatternLayout">
+	  <conversionPattern value="%date [%thread] [%file(%line)] [%property{LogSource} - %property{ActorPath}] %-5level %logger - UserId=%property{UserId}, Operation=%property{Operation} %class.%method - %message%newline" />
+	</layout>
+  </appender>
+  <root>
+	<level value="INFO" />
+	<appender-ref ref="ConsoleAppender" />
+  </root>
+</log4net>
+```
+
+This setup ensures your logs include all the specified details, making them more informative and easier to navigate.
+
+### Conclusion
+
+The log4net integration enhances Akka.NET's logging by allowing for detailed contextual information in logs. This not only improves diagnostics but also aids in understanding the execution flow and context of log messages.
 
 ## Maintainer
+
 - Akka.NET Team

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,3 @@
-#### 1.5.25 June 19 2025 ####
+#### 1.5.25 June 19 2024 ####
 
 * Support for [Akka.NET v1.5.25](https://github.com/akkadotnet/akka.net/releases/tag/1.5.25)

--- a/src/Akka.Logger.log4net.Tests/Akka.Logger.log4net.Tests.csproj
+++ b/src/Akka.Logger.log4net.Tests/Akka.Logger.log4net.Tests.csproj
@@ -1,0 +1,29 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>    
+    <TargetFrameworks>net472</TargetFrameworks>
+    <OutputType>Library</OutputType>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Akka" />
+    <PackageReference Include="Akka.TestKit.Xunit2" />
+    <PackageReference Include="FluentAssertions" />
+    <PackageReference Include="log4net" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="NSubstitute" />
+    <PackageReference Include="NSubstitute.Analyzers.CSharp">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Akka.Logger.log4net\Akka.Logger.log4net.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/Akka.Logger.log4net.Tests/Log4NetLoggerSpecs.cs
+++ b/src/Akka.Logger.log4net.Tests/Log4NetLoggerSpecs.cs
@@ -1,0 +1,182 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="Log4NetLoggerSpecs.cs" company="Akka.NET Project">
+//     Copyright (C) 2013-2017 Akka.NET Project <https://github.com/AkkaNetContrib>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using Akka.Event;
+using FluentAssertions;
+using log4net.Core;
+using log4net.Util;
+using NSubstitute;
+using System.Globalization;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Akka.Logger.log4net.Tests;
+
+public static class Log4NetLoggerSpecs
+{
+    public static readonly Exception Cause = new(nameof(Cause));
+
+    public static readonly Exception? NoCause = null;
+
+    private static LogEvent CreateLogEvent(Type logEventType, Exception? cause, LogSource logSource, object message)
+        => (LogEvent)Activator.CreateInstance(logEventType, cause, logSource.Source, logSource.Type, message);
+
+    private static Level GetLevelForLogEventType(Type logEventType)
+        => logEventType switch
+        {
+            var type when type == typeof(Debug) => Level.Debug,
+            var type when type == typeof(Info) => Level.Info,
+            var type when type == typeof(Warning) => Level.Warn,
+            var type when type == typeof(Error) => Level.Error,
+            _ => throw new ArgumentOutOfRangeException(nameof(logEventType)),
+        };
+
+    public class Method_CreateLoggingEvent(ITestOutputHelper output) : Log4NetSpecsBase(output)
+    {
+        private const string NA = Log4NetLogger.NA;
+
+        public static readonly object?[][] Should_return_LoggingEvent_with_message_and_properties_MemberData =
+        [
+            [typeof(Debug), Cause, Properties.Create()
+                .SetProperties(
+                    declaringType: typeof(Method_CreateLoggingEvent))
+                .AsReadOnly()],
+
+            [typeof(Info), NoCause, Properties.Create()
+                .SetProperties(
+                    declaringType: typeof(Method_CreateLoggingEvent),
+                    methodName: nameof(Should_return_LoggingEvent_with_message_and_properties))
+                .AsReadOnly()],
+
+            [typeof(Warning), Cause, Properties.Create()
+                .SetProperties(
+                    declaringType: typeof(Method_CreateLoggingEvent),
+                    methodName: nameof(Should_return_LoggingEvent_with_message_and_properties),
+                    fileName: "Log4NetLoggerSpec.cs")
+                .AsReadOnly()],
+
+            [typeof(Error), NoCause, Properties.Create()
+                .SetProperties(
+                    declaringType: typeof(Method_CreateLoggingEvent),
+                    methodName: nameof(Should_return_LoggingEvent_with_message_and_properties),
+                    fileName: "Log4NetLoggerSpec.cs",
+                    lineNumber: 42)
+                .AsReadOnly()],
+        ];
+
+        [Theory]
+        [MemberData(nameof(Should_return_LoggingEvent_with_message_and_properties_MemberData))]
+        public void Should_return_LoggingEvent_with_message_and_properties(Type logEventType, Exception? cause, ReadOnlyPropertiesDictionary contextProperties)
+        {
+            // Arrange
+
+            var logger = Substitute.For<ILogger>();
+
+            var level = GetLevelForLogEventType(logEventType);
+
+            const string message = nameof(message);
+
+            var log4NetPayload = new Log4NetPayload(message, contextProperties);
+
+            var logEvent = CreateLogEvent(logEventType, cause, LogSource, log4NetPayload);
+
+            var logEventSenderPath = TestActor.Path;
+
+            // Act
+
+            var loggingEvent = Log4NetLogger.CreateLoggingEvent(logger, level, logEvent, logEventSenderPath);
+
+            // Assert
+
+            loggingEvent.Level.Should().Be(level);
+            loggingEvent.LoggerName.Should().Be(LogSource.Type.FullName);
+
+            var eventData = loggingEvent.GetLoggingEventData();
+            eventData.Should().NotBeNull();
+
+            eventData.Message.Should().Be((string)log4NetPayload.Message);
+
+            eventData.ThreadName.Should().Be(Thread.CurrentThread.ManagedThreadId.ToString(NumberFormatInfo.InvariantInfo));
+
+            eventData.ExceptionString.Should().Be(cause?.ToString());
+
+            eventData.LocationInfo.Should().NotBeNull();
+            {
+                var locationInfo = eventData.LocationInfo;
+
+                locationInfo.ClassName.Should().Be(contextProperties.GetDeclaringTypeName() ?? NA);
+                locationInfo.MethodName.Should().Be(contextProperties.GetMethodName() ?? NA);
+                locationInfo.FileName.Should().Be(contextProperties.GetFileName() ?? NA);
+                locationInfo.LineNumber.Should().Be(contextProperties.GetLineNumber() ?? NA);
+            }
+
+            eventData.Properties.Should().NotBeNull();
+            {
+                var properties = eventData.Properties;
+
+                properties.GetActorPath().Should().Be(logEventSenderPath);
+                properties.GetLogSource().Should().Be(logEvent.LogSource);
+                properties.GetDeclaringTypeName().Should().Be(contextProperties.GetDeclaringTypeName());
+                properties.GetMethodName().Should().Be(contextProperties.GetMethodName());
+                properties.GetFileName().Should().Be(contextProperties.GetFileName());
+                properties.GetLineNumber().Should().Be(contextProperties.GetLineNumber());
+            }
+        }
+    }
+
+    public class Receive_LogEvent : Log4NetSpecsBase
+    {
+        private readonly ILogger _logger;
+
+        public Receive_LogEvent(ITestOutputHelper output) : base(output)
+        {
+            _logger = Substitute.For<ILogger>();
+
+            Log4NetLoggerActor.UnderlyingActor.GetLogger = _ => _logger;
+        }
+
+        [Theory]
+        [InlineData(typeof(Debug))]
+        [InlineData(typeof(Info))]
+        [InlineData(typeof(Warning))]
+        [InlineData(typeof(Error))]
+        public void Should_log_corresponding_LoggingEvent(Type logEventType)
+        {
+            // Arrange
+
+            var log4NetPayload = new Log4NetPayload(
+                message: nameof(Should_log_corresponding_LoggingEvent),
+                properties: Properties.Create().AsReadOnly());
+
+            var loggingEvents = new List<LoggingEvent>();
+            _logger.Log(Arg.Do<LoggingEvent>(loggingEvents.Add));
+
+            var logEvent = CreateLogEvent(logEventType, Cause, LogSource, log4NetPayload);
+
+            // Act
+
+            Log4NetLoggerActor.Receive(message: logEvent, sender: TestActor);
+
+            // Assert
+
+            var loggingEvent = loggingEvents.Should().ContainSingle().Subject;
+
+            loggingEvent.Level.Should().Be(GetLevelForLogEventType(logEventType));
+
+            loggingEvent.LoggerName.Should().Be(LogSource.Type.FullName);
+
+            loggingEvent.GetLoggingEventData().Should().NotBeNull();
+            {
+                var eventData = loggingEvent.GetLoggingEventData();
+
+                eventData.Message.Should().Be((string)log4NetPayload.Message);
+                eventData.ExceptionString.Should().Be(Cause.ToString());
+                eventData.LocationInfo.Should().NotBeNull();
+                eventData.Properties.Should().NotBeNull();
+            }
+        }
+    }
+}

--- a/src/Akka.Logger.log4net.Tests/Log4NetLoggingAdapterExtensionsSpecs.cs
+++ b/src/Akka.Logger.log4net.Tests/Log4NetLoggingAdapterExtensionsSpecs.cs
@@ -1,0 +1,106 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="Log4NetLoggingAdapterExtensionsSpecs.cs" company="Akka.NET Project">
+//     Copyright (C) 2013-2017 Akka.NET Project <https://github.com/AkkaNetContrib>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using FluentAssertions;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Akka.Logger.log4net.Tests;
+
+public static class Log4NetLoggingAdapterExtensionsSpecs
+{
+    public class Method_ForContext(ITestOutputHelper output) : Log4NetSpecsBase(output)
+    {
+        [Fact]
+        public void Should_throw_ArgumentNullException_When_adapter_is_null()
+        {
+            Action action = () => Log4NetLoggingAdapterExtensions.ForContext(
+                adapter: null!,
+                properties: new Dictionary<string, object?>());
+
+            action.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be("adapter");
+        }
+
+        [Fact]
+        public void Should_return_adapter_When_properties_and_real_world_context_is_null()
+        {
+            var loggingAdapter = Log4NetLoggingAdapter.ForContext(
+                properties: null, fileName: null, lineNumber: 0, methodName: null);
+
+            loggingAdapter.Should().BeSameAs(Log4NetLoggingAdapter);
+        }
+
+        [Fact]
+        public void Should_return_adapter_with_real_world_context()
+        {
+            var loggingAdapter = Log4NetLoggingAdapter.ForContext();
+
+            loggingAdapter.Should().NotBeNull();
+            loggingAdapter.Should().NotBeSameAs(Log4NetLoggingAdapter);
+            
+            var log4NetLoggingAdapter = loggingAdapter.Should().BeOfType<Log4NetLoggingAdapter>().Subject;
+            
+            var contextProperties = log4NetLoggingAdapter.GetContextProperties().AsEnumerable().ToArray();
+            
+            contextProperties.Should().ContainSingle(p => p.Key == Properties.FileName)
+                .Which.Value.Should().NotBeNull();
+            
+            contextProperties.Should().ContainSingle(p => p.Key == Properties.LineNumber)
+                .Which.Value.Should().NotBeNull();
+            
+            contextProperties.Should().ContainSingle(p => p.Key == Properties.MethodName);
+        }
+
+        [Fact]
+        public void Should_return_adapter_with_real_world_context_and_properties_added()
+        {
+            var properties = new Dictionary<string, object?>
+            {
+                ["key1"] = "value1",
+                ["key2"] = "value2",
+            };
+
+            var loggingAdapter = Log4NetLoggingAdapter.ForContext(
+                properties: properties);
+
+            loggingAdapter.Should().NotBeNull();
+            loggingAdapter.Should().NotBeSameAs(Log4NetLoggingAdapter);
+            var log4NetLoggingAdapter = loggingAdapter.Should().BeOfType<Log4NetLoggingAdapter>().Subject;
+
+            var contextProperties = log4NetLoggingAdapter.GetContextProperties().AsEnumerable().ToArray();
+
+            contextProperties.Should().ContainSingle(p => p.Key == Properties.FileName)
+                .Which.Value.Should().NotBeNull();
+
+            contextProperties.Should().ContainSingle(p => p.Key == Properties.LineNumber)
+                .Which.Value.Should().NotBeNull();
+
+            contextProperties.Should().ContainSingle(p => p.Key == Properties.MethodName);
+        }
+
+        [Fact]
+        public void Should_return_adapter_with_real_world_context_and_property_added()
+        {
+            var property = Properties.CreateProperty("key", "value");
+            var loggingAdapter = Log4NetLoggingAdapter.ForContext(propertyName: property.Key, value: property.Value);
+
+            loggingAdapter.Should().NotBeNull();
+            loggingAdapter.Should().NotBeSameAs(Log4NetLoggingAdapter);
+
+            var log4NetLoggingAdapter = loggingAdapter.Should().BeOfType<Log4NetLoggingAdapter>().Subject;
+
+            var contextProperties = log4NetLoggingAdapter.GetContextProperties().AsEnumerable().ToArray();
+
+            contextProperties.Should().ContainSingle(p => p.Key == Properties.FileName)
+                .Which.Value.Should().NotBeNull();
+
+            contextProperties.Should().ContainSingle(p => p.Key == Properties.LineNumber)
+                .Which.Value.Should().NotBeNull();
+
+            contextProperties.Should().ContainSingle(p => p.Key == Properties.MethodName);
+        }
+    }
+}

--- a/src/Akka.Logger.log4net.Tests/Log4NetLoggingAdapterSpecs.cs
+++ b/src/Akka.Logger.log4net.Tests/Log4NetLoggingAdapterSpecs.cs
@@ -1,0 +1,112 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="Log4NetLoggingAdapterSpecs.cs" company="Akka.NET Project">
+//     Copyright (C) 2013-2017 Akka.NET Project <https://github.com/AkkaNetContrib>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using Akka.Event;
+using FluentAssertions;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Akka.Logger.log4net.Tests;
+
+public static class Log4NetLoggingAdapterSpecs
+{
+    public class Method_BuildMessage(ITestOutputHelper output) : Log4NetSpecsBase(output)
+    {
+        [Fact]
+        public void Should_return_payload_with_message_and_properties()
+        {
+            const string message = "message";
+
+            var logginAdapter = Log4NetLoggingAdapter.SetContextProperties(new Dictionary<string, object?>
+            {
+                ["key1"] = "value1",
+                ["key2"] = "value2",
+            });
+
+            Log4NetPayload payload = logginAdapter.BuildMessage(message);
+
+            payload.Message.Should().Be(message);
+            payload.Properties.Should().BeEquivalentTo(logginAdapter.GetContextProperties());
+        }
+    }
+
+    public class Method_CreateLogEvent(ITestOutputHelper output) : Log4NetSpecsBase(output)
+    {
+        [Theory]
+        [InlineData(LogLevel.DebugLevel, typeof(Debug), true)]
+        [InlineData(LogLevel.DebugLevel, typeof(Debug), false)]
+        [InlineData(LogLevel.InfoLevel, typeof(Info), true)]
+        [InlineData(LogLevel.InfoLevel, typeof(Info), false)]
+        [InlineData(LogLevel.WarningLevel, typeof(Warning), true)]
+        [InlineData(LogLevel.WarningLevel, typeof(Warning), false)]
+        [InlineData(LogLevel.ErrorLevel, typeof(Error), true)]
+        [InlineData(LogLevel.ErrorLevel, typeof(Error), false)]
+        public void Should_return_LogEvent(LogLevel logLevel, Type logEventType, bool withCause)
+        {
+            const string message = "message";
+
+            var cause = withCause
+                ? new Exception("cause")
+                : null;
+
+            LogEvent logEvent = Log4NetLoggingAdapter.CreateLogEvent(logLevel, message: message, cause: cause);
+
+            logEvent.GetType().Should().Be(logEventType);
+            logEvent.LogLevel().Should().Be(logLevel);
+
+            var expectedPayload = Log4NetLoggingAdapter.BuildMessage(message);
+            var payload = logEvent.Message.Should().BeOfType<Log4NetPayload>().Subject;
+            payload.Message.Should().Be(expectedPayload.Message);
+            payload.Properties.Should().BeEquivalentTo(expectedPayload.Properties);
+            logEvent.Cause.Should().BeSameAs(cause);
+        }
+    }
+
+    public class Method_SetContextProperties(ITestOutputHelper output) : Log4NetSpecsBase(output)
+    {
+        [Fact]
+        public void Should_return_adapter_When_properties_is_null()
+        {
+            var loggingAdapter = Log4NetLoggingAdapter.SetContextProperties(properties: null!);
+            loggingAdapter.Should().BeSameAs(Log4NetLoggingAdapter);
+        }
+
+        [Fact]
+        public void Should_return_adapter_When_properties_is_empty()
+        {
+            var loggingAdapter = Log4NetLoggingAdapter.SetContextProperties(properties: []);
+            loggingAdapter.Should().BeSameAs(Log4NetLoggingAdapter);
+        }
+
+        [Fact]
+        public void Should_return_new_adapter_with_properties_added_When_properties_is_not_empty()
+        {
+            IEnumerable<KeyValuePair<string, object?>> properties = new Dictionary<string, object?>
+            {
+                ["key1"] = "value1",
+                ["key2"] = "value2",
+            };
+
+            var loggingAdapter = Log4NetLoggingAdapter.SetContextProperties(properties);
+            
+            loggingAdapter.Should().NotBeNull();
+            loggingAdapter.Should().NotBeSameAs(Log4NetLoggingAdapter);
+            loggingAdapter.GetContextProperties().AsEnumerable().Should().BeEquivalentTo(properties);
+        }
+
+        [Fact]
+        public void Should_return_new_adapter_with_property_added()
+        {
+            var property = Properties.CreateProperty("key1", "value1");
+
+            var loggingAdapter = Log4NetLoggingAdapter.SetContextProperty(propertyName: property.Key, value: property.Value);
+
+            loggingAdapter.Should().NotBeNull();
+            loggingAdapter.Should().NotBeSameAs(Log4NetLoggingAdapter);
+            loggingAdapter.GetContextProperties().AsEnumerable().Should().BeEquivalentTo([property]);
+        }
+    }
+}

--- a/src/Akka.Logger.log4net.Tests/Log4NetPayloadSpecs.cs
+++ b/src/Akka.Logger.log4net.Tests/Log4NetPayloadSpecs.cs
@@ -1,0 +1,69 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="Log4NetPayloadSpecs.cs" company="Akka.NET Project">
+//     Copyright (C) 2013-2017 Akka.NET Project <https://github.com/AkkaNetContrib>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using FluentAssertions;
+using log4net.Util;
+using Xunit;
+
+namespace Akka.Logger.log4net.Tests;
+
+public static class Log4NetPayloadSpecs
+{
+    public class Ctor
+    {
+        [Fact]
+        public void Should_create_instance_with_message_and_properties()
+        {
+            const string message = nameof(message);
+            
+            var properties = Properties.Create()
+                .SetProperties([Properties.CreateProperty("key", "value")])
+                .AsReadOnly();
+
+            var payload = new Log4NetPayload(message, properties);
+            payload.Message.Should().Be(message);
+            payload.Properties.Should().BeEquivalentTo(properties);
+        }
+
+        [Fact]
+        public void Should_throw_ArgumentNullException_When_message_is_null()
+        {
+            Action action = () => _ = new Log4NetPayload(message: null!, properties: []);
+            action.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be("message");
+        }
+
+        [Fact]
+        public void Should_have_empty_properties_When_properties_is_null()
+        {
+            var payload = new Log4NetPayload(message: "message", properties: null!);
+            payload.Properties.Should().NotBeNull();
+            payload.Properties.Should().BeEquivalentTo<ReadOnlyPropertiesDictionary>([]);
+        }
+    }
+
+    public class Field_Empty
+    {
+        [Fact]
+        public void Should_be_correctly_initialized()
+        {
+            var empty = Log4NetPayload.Empty;
+            empty.Message.Should().NotBeNull();
+            empty.Properties.Should().NotBeNull();
+            empty.Properties.Should().BeEquivalentTo<ReadOnlyPropertiesDictionary>([]);
+        }
+    }
+
+    public class Method_ToString
+    {
+        [Fact]
+        public void  Should_return_Message_from_ToString()
+        {
+            const string message = nameof(message);
+            var payload = new Log4NetPayload(message, properties: []);
+            payload.ToString().Should().Be(message);
+        }
+    }
+}

--- a/src/Akka.Logger.log4net.Tests/Log4NetSpecsBase.cs
+++ b/src/Akka.Logger.log4net.Tests/Log4NetSpecsBase.cs
@@ -1,0 +1,45 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="Log4NetSpecsBase.cs" company="Akka.NET Project">
+//     Copyright (C) 2013-2017 Akka.NET Project <https://github.com/AkkaNetContrib>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using Akka.Configuration;
+using Akka.Event;
+using Akka.TestKit;
+using Xunit.Abstractions;
+
+namespace Akka.Logger.log4net.Tests;
+
+public abstract class Log4NetSpecsBase : TestKit.Xunit2.TestKit
+{
+    public static readonly Config Config =
+        """
+            akka.loglevel = DEBUG
+            akka.loggers=["Akka.Logger.log4net.Log4NetLogger, Akka.Logger.log4net"]
+            """;
+
+    private readonly LogSource _logSource;
+    private readonly Lazy<Log4NetLoggingAdapter> _loggingAdapter;
+    private readonly Lazy<TestActorRef<Log4NetLogger>> _log4NetLoggerActor;
+
+    protected Log4NetSpecsBase(ITestOutputHelper output)
+        : base(Config, output: output)
+    {
+        _logSource = LogSource.Create(TestActor);
+        _loggingAdapter = new(CreateLoggingAdapter);
+        _log4NetLoggerActor = new(CreateLog4NetLogger);
+    }
+
+    protected LogSource LogSource => _logSource;
+
+    protected Log4NetLoggingAdapter Log4NetLoggingAdapter => _loggingAdapter.Value;
+
+    protected TestActorRef<Log4NetLogger> Log4NetLoggerActor => _log4NetLoggerActor.Value;
+
+    private Log4NetLoggingAdapter CreateLoggingAdapter()
+        => (Log4NetLoggingAdapter)Sys.GetLogger(LogSource.Source, LogSource.Type);
+
+    private TestActorRef<Log4NetLogger> CreateLog4NetLogger()
+        => ActorOfAsTestActorRef(() => new Log4NetLogger(), name: nameof(Log4NetLogger));
+}

--- a/src/Akka.Logger.log4net.Tests/PropertiesDictionaryExtensionsSpecs.cs
+++ b/src/Akka.Logger.log4net.Tests/PropertiesDictionaryExtensionsSpecs.cs
@@ -1,0 +1,63 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="PropertiesDictionaryExtensionsSpecs.cs" company="Akka.NET Project">
+//     Copyright (C) 2013-2017 Akka.NET Project <https://github.com/AkkaNetContrib>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using FluentAssertions;
+using System.Collections;
+using Xunit;
+
+namespace Akka.Logger.log4net.Tests;
+
+public static class PropertiesDictionaryExtensionsSpecs
+{
+    public class Method_SetProperties
+    {
+        [Fact]
+        public void Should_set_properties()
+        {
+            var keyValuePairs = new[]
+            {
+                Properties.CreateProperty("key1", "value1"),
+                Properties.CreateProperty("key2", "value2"),
+            };
+
+            var properties = Properties.Create().SetProperties(keyValuePairs);
+
+            properties.Should().BeEquivalentTo(keyValuePairs);
+        }
+
+        [Fact]
+        public void Should_overwrite_existing_properties()
+        {
+            var properties = Properties.Create()
+                .SetProperties([Properties.CreateProperty("key", "value")]);
+
+            var keyValuePairs = new[] { Properties.CreateProperty("key", "new value") };
+
+            properties.SetProperties(keyValuePairs);
+
+            properties.Should().BeEquivalentTo((IEnumerable)keyValuePairs);
+        }
+    }
+
+    public class Method_AsEnumerable
+    {
+        [Fact]
+        public void Should_return_properties_as_key_value_pairs()
+        {
+            var keyValuePairs = new[]
+            {
+                Properties.CreateProperty("key1", "value1"),
+                Properties.CreateProperty("key2", "value2"),
+            };
+
+            var properties = Properties.Create()
+                .SetProperties(keyValuePairs)
+                .AsEnumerable();
+
+            properties.Should().BeEquivalentTo(keyValuePairs);
+        }
+    }
+}

--- a/src/Akka.Logger.log4net.sln
+++ b/src/Akka.Logger.log4net.sln
@@ -1,9 +1,9 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 14
-VisualStudioVersion = 14.0.24720.0
+# Visual Studio Version 17
+VisualStudioVersion = 17.10.35013.160
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Akka.Logger.log4net", "Akka.Logger.log4net\Akka.Logger.log4net.csproj", "{8B57B754-24FC-4825-8A50-B9E3F919BB3A}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Akka.Logger.log4net", "Akka.Logger.log4net\Akka.Logger.log4net.csproj", "{8B57B754-24FC-4825-8A50-B9E3F919BB3A}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{828A76CC-8178-4470-B20B-DA78673D91C4}"
 	ProjectSection(SolutionItems) = preProject
@@ -32,6 +32,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "scripts", "scripts", "{7343
 		..\scripts\getReleaseNotes.ps1 = ..\scripts\getReleaseNotes.ps1
 	EndProjectSection
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Akka.Logger.log4net.Tests", "Akka.Logger.log4net.Tests\Akka.Logger.log4net.Tests.csproj", "{F2BC0EB5-17AF-46A3-B0A9-935B1803504F}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -42,6 +44,10 @@ Global
 		{8B57B754-24FC-4825-8A50-B9E3F919BB3A}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{8B57B754-24FC-4825-8A50-B9E3F919BB3A}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{8B57B754-24FC-4825-8A50-B9E3F919BB3A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F2BC0EB5-17AF-46A3-B0A9-935B1803504F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F2BC0EB5-17AF-46A3-B0A9-935B1803504F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F2BC0EB5-17AF-46A3-B0A9-935B1803504F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F2BC0EB5-17AF-46A3-B0A9-935B1803504F}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -50,5 +56,8 @@ Global
 		{D27357E5-702C-4E85-95A1-969FDCF765A6} = {828A76CC-8178-4470-B20B-DA78673D91C4}
 		{7AD6435A-870C-4D7D-859D-9FF1C5C72C58} = {D27357E5-702C-4E85-95A1-969FDCF765A6}
 		{73437FA7-88B8-4F5E-95B4-EF09F65AF87E} = {828A76CC-8178-4470-B20B-DA78673D91C4}
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {F927F8DD-8EEC-49AB-BDD2-EC7CE44C3FF9}
 	EndGlobalSection
 EndGlobal

--- a/src/Akka.Logger.log4net/Akka.Logger.log4net.csproj
+++ b/src/Akka.Logger.log4net/Akka.Logger.log4net.csproj
@@ -8,4 +8,10 @@
     <PackageReference Include="Akka" />
     <PackageReference Include="log4net" />
   </ItemGroup>
+
+  <ItemGroup>
+    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
+      <_Parameter1>Akka.Logger.log4net.Tests</_Parameter1>
+    </AssemblyAttribute>
+  </ItemGroup>
 </Project>

--- a/src/Akka.Logger.log4net/Log4NetLoggingAdapter.cs
+++ b/src/Akka.Logger.log4net/Log4NetLoggingAdapter.cs
@@ -5,22 +5,35 @@
 //-----------------------------------------------------------------------
 
 using Akka.Event;
+using log4net.Util;
+using System.Diagnostics;
+using System.Reflection;
 
 namespace Akka.Logger.log4net
 {
-    public class Log4NetLoggingAdapter : LoggingAdapterBase
+    using Debug = Event.Debug;
+
+    /// <summary>
+    /// The logging adapter used for creating <see cref="LogEvent"/> instances and publishing them
+    /// to the <see cref="LoggingBus"/>.
+    /// </summary>
+    public sealed class Log4NetLoggingAdapter : LoggingAdapterBase
     {
         private readonly LoggingBus _bus;
-        private readonly Type _logClass;
-        private readonly string _logSource;
+        private readonly LogSource _logSource;
+        private readonly PropertyNode _propertyNodeListHead;
 
-        /// <inheritdoc />
-        public Log4NetLoggingAdapter(LoggingBus bus, string logSource, Type logClass)
+        public Log4NetLoggingAdapter(LoggingBus bus, LogSource logSource)
+            : this(bus, logSource, PropertyNode.Empty)
+        {
+        }
+
+        private Log4NetLoggingAdapter(LoggingBus bus, LogSource logSource, PropertyNode propertyNode)
             : base(Log4NetMessageFormatter.Instance)
         {
             _bus = bus;
             _logSource = logSource;
-            _logClass = logClass;
+            _propertyNodeListHead = propertyNode;
 
             IsErrorEnabled = bus.LogLevel <= LogLevel.ErrorLevel;
             IsWarningEnabled = bus.LogLevel <= LogLevel.WarningLevel;
@@ -28,13 +41,13 @@ namespace Akka.Logger.log4net
             IsDebugEnabled = bus.LogLevel <= LogLevel.DebugLevel;
         }
 
-        private LogEvent CreateLogEvent(LogLevel logLevel, object message, Exception? cause = null)
+        internal LogEvent CreateLogEvent(LogLevel logLevel, object message, Exception? cause = null)
             => logLevel switch
             {
-                LogLevel.DebugLevel => new Debug(cause, _logSource, _logClass, message),
-                LogLevel.InfoLevel => new Info(cause, _logSource, _logClass, message),
-                LogLevel.WarningLevel => new Warning(cause, _logSource, _logClass, message),
-                LogLevel.ErrorLevel => new Error(cause, _logSource, _logClass, message),
+                LogLevel.DebugLevel => new Debug(cause, _logSource.Source, _logSource.Type, BuildMessage(message)),
+                LogLevel.InfoLevel => new Info(cause, _logSource.Source, _logSource.Type, BuildMessage(message)),
+                LogLevel.WarningLevel => new Warning(cause, _logSource.Source, _logSource.Type, BuildMessage(message)),
+                LogLevel.ErrorLevel => new Error(cause, _logSource.Source, _logSource.Type, BuildMessage(message)),
                 _ => throw new ArgumentOutOfRangeException(nameof(logLevel), logLevel, message: null)
             };
 
@@ -53,5 +66,178 @@ namespace Akka.Logger.log4net
 
         /// <inheritdoc />
         public override bool IsErrorEnabled { get; }
+
+        /// <summary>
+        /// Get the configured context properties.
+        /// </summary>
+        /// <returns>The context proeprties.</returns>
+        public PropertiesDictionary GetContextProperties()
+            => Properties.Create().SetProperties(_propertyNodeListHead.GetProperties());
+
+        /// <summary>
+        /// Set a context property for the logger.
+        /// </summary>
+        /// <param name="propertyName">The property name.</param>
+        /// <param name="value">The property value.</param>
+        /// <returns>A new instance of this class which has the provided property set.</returns>
+        public Log4NetLoggingAdapter SetContextProperty(string propertyName, object? value)
+        {
+            var property = Properties.CreateProperty(propertyName, value);
+            var propertyNode = _propertyNodeListHead.Add(property);
+            return new Log4NetLoggingAdapter(_bus, _logSource, propertyNode);
+        }
+
+        /// <summary>
+        /// Set a range of context properties for the logger.
+        /// </summary>
+        /// <param name="properties">The properties to set.</param>
+        /// <returns>A new instance of this class which has the provided properties set.</returns>
+        public Log4NetLoggingAdapter SetContextProperties(IEnumerable<KeyValuePair<string, object?>> properties)
+        {
+            properties ??= [];
+
+            var propertyNode = _propertyNodeListHead.AddRange(properties);
+            return ReferenceEquals(propertyNode, _propertyNodeListHead)
+                ? this
+                : new Log4NetLoggingAdapter(_bus, _logSource, propertyNode);
+        }
+
+        /// <summary>
+        /// Create a new <see cref="Log4NetPayload"/> with the provided <paramref name="message"/>
+        /// and all the properties in the linked list represented by the <see cref="_propertyNodeListHead"/>.
+        /// </summary>
+        /// <param name="message">The log message.</param>
+        /// <returns>The corresponding <see cref="Log4NetPayload"/>.</returns>
+        internal Log4NetPayload BuildMessage(object message)
+        {
+            var properties = GetContextProperties();
+            AddCallerInfoFromStackTraceIfMissing(properties);
+            return new(message, properties);
+        }
+
+        /// <summary>
+        /// Only consult the stack trace for adding missing caller info if it is not already present.
+        /// </summary>
+        /// <remarks>
+        /// This is to avoid the overhead of stack trace generation if it is not needed.
+        /// </remarks>
+        /// <param name="properties">The properties to be supplemented with caller info.</param>
+        internal void AddCallerInfoFromStackTraceIfMissing(PropertiesDictionary properties)
+        {
+            // If complete caller info is already present then there is no need to add it again
+            // (and we can avoid to create a costly stack trace).
+            if (Properties.CallerInfoProperties.All(properties.Contains))
+                return;
+
+            // If the caller stack frame cannot be found then we cannot add caller info.
+            if (GetCallerStackFrame(_logSource.Type) is not { } frame)
+                return;
+            
+            if (frame.GetMethod() is { } method)
+            {
+                properties.SetDeclaringTypeName(method.DeclaringType);
+                properties.SetMethodName(method.Name);
+            }
+
+            if (frame.GetFileLineNumber() is { } lineNumber and > 0)
+                properties.SetLineNumber(lineNumber);
+
+            if (frame.GetFileName() is { } fileName)
+                properties.SetFileName(fileName);
+
+            #region Helper function(s)
+
+            // Get the stack frame of the caller of the method in the provided type.
+            static StackFrame? GetCallerStackFrame(Type logClass)
+                => new StackTrace(fNeedFileInfo: true)
+                    .GetFrames()
+                    .FirstOrDefault(frame => GetDeclaringTypes(frame.GetMethod()).Contains(logClass));
+
+            // Get the declaring type of the method as well as all declaring types up to the root type.
+            static IEnumerable<Type> GetDeclaringTypes(MethodBase method)
+            {
+                var type = method.DeclaringType;
+                while (type is not null)
+                {
+                    yield return type;
+                    type = type.DeclaringType;
+                }
+            }
+
+            #endregion
+        }
+
+        /// <summary>
+        /// Represents a property in a single-linked list of properties.
+        /// </summary>
+        private sealed record PropertyNode
+        {
+            /// <summary>
+            /// Represents an empty instance of this class.
+            /// </summary>
+            public static readonly PropertyNode Empty = new(
+                property: Properties.CreateProperty(string.Empty, null),
+                next: null!);
+
+            /// <summary>
+            /// The property represented as key-value pair.
+            /// </summary>
+            public KeyValuePair<string, object?> Property { get; }
+
+            /// <summary>
+            /// The next property node in the linked list.
+            /// </summary>
+            public PropertyNode Next { get; }
+
+            /// <summary>
+            /// Create a new instance of this class which will be the head of a linked
+            /// list of properties.
+            /// </summary>
+            /// <param name="property">The property to add.</param>
+            /// <param name="next">The old head of the linked list.</param>
+            public PropertyNode(KeyValuePair<string, object?> property, PropertyNode next)
+            {
+                this.Property = property;
+                this.Next = next;
+            }
+
+            /// <summary>
+            /// Add a new property to the head of the linked list (by returning a new <see cref="PropertyNode"/>
+            /// as the new head of the linked list).
+            /// </summary>
+            /// <param propertyName="propertyName">The property propertyName (must not be <c>null</c>.</param>
+            /// <param propertyName="value">The property value.</param>
+            /// <returns>A new <see cref="PropertyNode"/> as the new head of the linked list.</returns>
+            public PropertyNode Add(KeyValuePair<string, object?> property)
+                => new(property, this);
+
+            /// <summary>
+            /// Add a range of properties to the head of the linked list.
+            /// </summary>
+            /// <param propertyName="properties">The properties to add.</param>
+            /// <returns>A new <see cref="PropertyNode"/> as the new head of the linked list.</returns>
+            public PropertyNode AddRange(IEnumerable<KeyValuePair<string, object?>> properties)
+            {
+                var currentNode = this;
+                foreach (var property in properties)
+                    currentNode = currentNode.Add(property);
+
+                return currentNode;
+            }
+
+            /// <summary>
+            /// Return all properties stored in the linked list.
+            /// </summary>
+            /// <returns>The properties stored in the linked list.</returns>
+            public IEnumerable<KeyValuePair<string, object?>> GetProperties()
+            {
+                var currentNode = this;
+                while (currentNode != Empty)
+                {
+                    yield return currentNode!.Property;
+                    currentNode = currentNode.Next;
+                }
+            }
+        }
     }
 }

--- a/src/Akka.Logger.log4net/Log4NetLoggingAdapter.cs
+++ b/src/Akka.Logger.log4net/Log4NetLoggingAdapter.cs
@@ -1,4 +1,10 @@
-﻿using Akka.Event;
+﻿//-----------------------------------------------------------------------
+// <copyright file="Log4NetLoggingAdapter.cs" company="Akka.NET Project">
+//     Copyright (C) 2013-2017 Akka.NET Project <https://github.com/AkkaNetContrib>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using Akka.Event;
 
 namespace Akka.Logger.log4net
 {

--- a/src/Akka.Logger.log4net/Log4NetLoggingAdapterExtensions.cs
+++ b/src/Akka.Logger.log4net/Log4NetLoggingAdapterExtensions.cs
@@ -120,8 +120,7 @@ namespace Akka.Logger.log4net
         /// </summary>
         /// <param name="context">The context used to configure the logging adapter.</param>
         /// <returns>The newly created logging adapter.</returns>
-        public static ILoggingAdapter GetLogger<T>(this IActorContext context)
-            where T : class, ILoggingAdapter
+        public static ILoggingAdapter GetLogger(this IActorContext context)
         {
             if (context is null)
                 throw new ArgumentNullException(nameof(context));
@@ -129,8 +128,7 @@ namespace Akka.Logger.log4net
             return new Log4NetLoggingAdapter(context.System.EventStream, LogSource.Create(context));
         }
 
-        public static ILoggingAdapter GetLogger<T>(this ActorSystem system, object logSourceObj)
-            where T : class, ILoggingAdapter
+        public static ILoggingAdapter GetLogger(this ActorSystem system, object logSourceObj)
         {
             if (system is null)
                 throw new ArgumentNullException(nameof(system));
@@ -141,8 +139,7 @@ namespace Akka.Logger.log4net
             return new Log4NetLoggingAdapter(system.EventStream, LogSource.Create(logSourceObj, system));
         }
 
-        public static ILoggingAdapter GetLogger<T>(this ActorSystem system, string logSource, Type logType)
-            where T : class, ILoggingAdapter
+        public static ILoggingAdapter GetLogger(this ActorSystem system, string logSource, Type logType)
         {
             if (system is null)
                 throw new ArgumentNullException(nameof(system));

--- a/src/Akka.Logger.log4net/Log4NetLoggingAdapterExtensions.cs
+++ b/src/Akka.Logger.log4net/Log4NetLoggingAdapterExtensions.cs
@@ -4,14 +4,117 @@
 // </copyright>
 //-----------------------------------------------------------------------
 
-using System;
 using Akka.Actor;
 using Akka.Event;
+using System.Runtime.CompilerServices;
 
 namespace Akka.Logger.log4net
 {
+    /// <summary>
+    /// Provides extension methods for <see cref="ILoggingAdapter"/>.
+    /// </summary>
     public static class Log4NetLoggingAdapterExtensions
     {
+        /// <summary>
+        /// Create a logger that enriches log events with the specified property.
+        /// </summary>
+        /// <remarks>
+        /// The method parameters <paramref name="fileName"/>, <paramref name="lineNumber"/>
+        /// and <paramref name="methodName"/> will be default initialized with "real-world"
+        /// context information. So, you might want to let them untouched.
+        /// </remarks>
+        /// <param name="adapter">ILoggingAdapter instance</param>
+        /// <param name="propertyName">The name of the property. Must be non-empty.</param>
+        /// <param name="value">The property value.</param>
+        /// <param name="fileName">The file name to log.</param>
+        /// <param name="lineNumber">The line number to log.</param>
+        /// <param name="methodName">The method name to log.</param>
+        public static ILoggingAdapter ForContext(
+            this ILoggingAdapter adapter,
+            string propertyName,
+            object? value,
+            [CallerFilePath] string? fileName = null,
+            [CallerLineNumber] int lineNumber = 0,
+            [CallerMemberName] string? methodName = null)
+        {
+            return ForContext(
+                adapter: adapter,
+                properties: [Properties.CreateProperty(propertyName, value)],
+                fileName: fileName,
+                lineNumber: lineNumber,
+                methodName: methodName);
+        }
+
+        /// <summary>
+        /// Create a logger that enriches log events with the specified property.
+        /// </summary>
+        /// <remarks>
+        /// The method parameters <paramref name="fileName"/>, <paramref name="lineNumber"/>
+        /// and <paramref name="methodName"/> will be default initialized with "real-world"
+        /// context information. So, you might want to let them untouched.
+        /// </remarks>
+        /// <param name="adapter">ILoggingAdapter instance</param>
+        /// <param name="properties">The properties to log.</param>
+        /// <param name="fileName">The file name to log.</param>
+        /// <param name="lineNumber">The line number to log.</param>
+        /// <param name="methodName">The method name to log.</param>
+        public static ILoggingAdapter ForContext(
+            this ILoggingAdapter adapter,
+            IEnumerable<KeyValuePair<string, object?>>? properties = null,
+            [CallerFilePath] string? fileName = null,
+            [CallerLineNumber] int lineNumber = 0,
+            [CallerMemberName] string? methodName = null)
+        {
+            if (adapter is null)
+                throw new ArgumentNullException(nameof(adapter));
+
+            // Log a warning if for the provided 'adapter' no 'Log4NetLoggingAdapter' can be obtained.
+            if (Log4NetLoggingAdapterFor(adapter, out var errorMessage) is not { } enrichedAdapter)
+            {
+                adapter.Warning(errorMessage!);
+                return adapter;
+            }
+
+            if (fileName is not null)
+                enrichedAdapter = enrichedAdapter.SetContextProperty(Properties.FileName, fileName);
+
+            if (lineNumber > 0)
+                enrichedAdapter = enrichedAdapter.SetContextProperty(Properties.LineNumber, lineNumber);
+
+            if (methodName is not null)
+                enrichedAdapter = enrichedAdapter.SetContextProperty(Properties.MethodName, methodName);
+
+            if (properties is not null)
+                enrichedAdapter = enrichedAdapter.SetContextProperties(properties);
+
+            return enrichedAdapter;
+
+            #region Helper functions(s)
+
+            // Try to get a 'Log4NetLoggingAdapter' from the provided 'adapter'.
+            static Log4NetLoggingAdapter? Log4NetLoggingAdapterFor(ILoggingAdapter adapter, out string? errorMessage)
+            {
+                switch (adapter)
+                {
+                    case Log4NetLoggingAdapter log4NetLoggingAdapter:
+                        errorMessage = null;
+                        return log4NetLoggingAdapter;
+
+                    case BusLogging defaultAkkaAdapter:
+                        errorMessage = null;
+                        return new Log4NetLoggingAdapter(
+                            defaultAkkaAdapter.Bus,
+                            LogSource.Create(defaultAkkaAdapter.LogSource, defaultAkkaAdapter.LogClass));
+
+                    default:
+                        errorMessage = $"Cannot enrich log event with properties because the adapter is not a {typeof(Log4NetLoggingAdapter)} or {typeof(BusLogging)}.";
+                        return null;
+                }
+            }
+
+            #endregion
+        }
+
         /// <summary>
         /// Creates a new logging adapter using the specified context's event stream.
         /// </summary>
@@ -20,26 +123,34 @@ namespace Akka.Logger.log4net
         public static ILoggingAdapter GetLogger<T>(this IActorContext context)
             where T : class, ILoggingAdapter
         {
-            var logSource = context.Self.ToString();
-            var logClass = context.Props.Type;
+            if (context is null)
+                throw new ArgumentNullException(nameof(context));
 
-            return new Log4NetLoggingAdapter(context.System.EventStream, logSource, logClass);
+            return new Log4NetLoggingAdapter(context.System.EventStream, LogSource.Create(context));
         }
 
         public static ILoggingAdapter GetLogger<T>(this ActorSystem system, object logSourceObj)
             where T : class, ILoggingAdapter
         {
+            if (system is null)
+                throw new ArgumentNullException(nameof(system));
+
             if (logSourceObj is null)
                 throw new ArgumentNullException(nameof(logSourceObj));
 
-            var logSource = LogSource.Create(logSourceObj, system);
-            return new Log4NetLoggingAdapter(system.EventStream, logSource.Source, logSource.Type);
+            return new Log4NetLoggingAdapter(system.EventStream, LogSource.Create(logSourceObj, system));
         }
 
         public static ILoggingAdapter GetLogger<T>(this ActorSystem system, string logSource, Type logType)
             where T : class, ILoggingAdapter
         {
-            return new Log4NetLoggingAdapter(system.EventStream, logSource, logType);
+            if (system is null)
+                throw new ArgumentNullException(nameof(system));
+
+            if (logSource is null)
+                throw new ArgumentNullException(nameof(logSource));
+
+            return new Log4NetLoggingAdapter(system.EventStream, LogSource.Create(logSource, logType));
         }
     }
 }

--- a/src/Akka.Logger.log4net/Log4NetLoggingAdapterExtensions.cs
+++ b/src/Akka.Logger.log4net/Log4NetLoggingAdapterExtensions.cs
@@ -1,4 +1,10 @@
-﻿using System;
+﻿//-----------------------------------------------------------------------
+// <copyright file="Log4NetLoggingAdapterExtensions.cs" company="Akka.NET Project">
+//     Copyright (C) 2013-2017 Akka.NET Project <https://github.com/AkkaNetContrib>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System;
 using Akka.Actor;
 using Akka.Event;
 

--- a/src/Akka.Logger.log4net/Log4NetMessageFormatter.cs
+++ b/src/Akka.Logger.log4net/Log4NetMessageFormatter.cs
@@ -1,4 +1,10 @@
-﻿using Akka.Event;
+﻿//-----------------------------------------------------------------------
+// <copyright file="Log4NetMessageFormatter.cs" company="Akka.NET Project">
+//     Copyright (C) 2013-2017 Akka.NET Project <https://github.com/AkkaNetContrib>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using Akka.Event;
 
 namespace Akka.Logger.log4net
 {

--- a/src/Akka.Logger.log4net/Log4NetPayload.cs
+++ b/src/Akka.Logger.log4net/Log4NetPayload.cs
@@ -1,0 +1,47 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="Log4NetPayload.cs" company="Akka.NET Project">
+//     Copyright (C) 2013-2017 Akka.NET Project <https://github.com/AkkaNetContrib>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using log4net.Util;
+
+namespace Akka.Logger.log4net
+{
+    /// <summary>
+    /// Will be sent by the <see cref="Log4NetLoggingAdapter"/> as a log message. It wraps the
+    /// original log message and the propsDict to be logged.
+    /// </summary>
+    internal readonly record struct Log4NetPayload
+    {
+        /// <summary>
+        /// An empty instance of this class.
+        /// </summary>
+        public static readonly Log4NetPayload Empty = new(message: new object(), properties: []);
+
+        /// <summary>
+        /// The message to be logged.
+        /// </summary>
+        public object Message { get; } = Empty.Message;
+
+        /// <summary>
+        /// The propsDict to be logged.
+        /// </summary>
+        public ReadOnlyPropertiesDictionary Properties { get; } = Empty.Properties;
+
+        /// <summary>
+        /// Create an instance of this class with the specified message and properties.
+        /// </summary>
+        /// <param name="message">The message to be logged.</param>
+        /// <param name="properties">The propsDict to be logged.</param>
+        public Log4NetPayload(object message, ReadOnlyPropertiesDictionary properties)
+        {
+            Message = message ?? throw new ArgumentNullException(nameof(message));
+            Properties = properties ?? Empty.Properties;
+        }
+
+        /// <inheritdoc />
+        public override string ToString()
+            => Message.ToString();
+    }
+}

--- a/src/Akka.Logger.log4net/Properties.cs
+++ b/src/Akka.Logger.log4net/Properties.cs
@@ -1,0 +1,64 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="Properties.cs" company="Akka.NET Project">
+//     Copyright (C) 2013-2017 Akka.NET Project <https://github.com/AkkaNetContrib>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using Akka.Actor;
+using log4net.Util;
+using System.Runtime.CompilerServices;
+
+namespace Akka.Logger.log4net
+{
+    /// <summary>
+    /// This class contains the property names used to enrich log events.
+    /// </summary>
+    public static class Properties
+    {
+        public static readonly IReadOnlyCollection<string> CallerInfoProperties =
+        [
+            DeclaringTypeName,
+            FileName,
+            LineNumber,
+            MethodName
+        ];
+
+        /// <summary>
+        /// Property name for the actor path of the actor which created the log event.
+        /// </summary>
+        public const string ActorPath = nameof(ActorPath);
+
+        /// <summary>
+        /// Property name for the class name of the method which created the log event.
+        /// </summary>
+        public const string DeclaringTypeName = nameof(DeclaringTypeName);
+
+        /// <summary>
+        /// Property name for the file name of the source file from where the log event was created.
+        /// </summary>
+        public const string FileName = nameof(FileName);
+
+        /// <summary>
+        /// Property name for the source line number in the source file from where the log event was created.
+        /// </summary>
+        public const string LineNumber = nameof(LineNumber);
+
+        /// <summary>
+        /// Property name for the log source of the log event.
+        /// </summary>
+        public const string LogSource = nameof(LogSource);
+
+        /// <summary>
+        /// Property name for the method name of the method which created the log event.
+        /// </summary>
+        public const string MethodName = nameof(MethodName);
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal static KeyValuePair<string, object?> CreateProperty(string propertyName, object? value)
+            => new(propertyName, value);
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal static PropertiesDictionary Create()
+            => new();
+    }
+}

--- a/src/Akka.Logger.log4net/PropertiesDictionaryExtensions.cs
+++ b/src/Akka.Logger.log4net/PropertiesDictionaryExtensions.cs
@@ -1,0 +1,128 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="PropertiesDictionaryExtensions.cs" company="Akka.NET Project">
+//     Copyright (C) 2013-2017 Akka.NET Project <https://github.com/AkkaNetContrib>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using Akka.Actor;
+using log4net.Util;
+using System.Collections;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Runtime.CompilerServices;
+
+namespace Akka.Logger.log4net
+{
+    /// <summary>
+    /// Provides extension methods for <see cref="PropertiesDictionary"/>.
+    /// </summary>
+    public static class PropertiesDictionaryExtensions
+    {
+        internal static PropertiesDictionary SetProperties(
+            this PropertiesDictionary properties,
+            Type? declaringType = null,
+            string? methodName = null,
+            string? fileName = null,
+            int lineNumber = 0,
+            ActorPath? actorPath = null,
+            string? logSource = null)
+        {
+            if (actorPath is not null)
+                properties.SetActorPath(actorPath);
+
+            if (lineNumber > 0)
+                properties.SetLineNumber(lineNumber);
+
+            if (declaringType is not null)
+                properties.SetDeclaringTypeName(declaringType);
+
+            if (methodName is not null)
+                properties.SetMethodName(methodName);
+
+            if (fileName is not null)
+                properties.SetFileName(fileName);
+
+            if (logSource is not null)
+                properties.SetLogSource(logSource);
+
+            return properties;
+        }
+        
+        /// <summary>
+        /// Add a range of key-value pairs to the <see cref="PropertiesDictionary"/>.
+        /// </summary>
+        /// <param name="properties">The properties to modify.</param>
+        /// <param name="keyValuePairs">The properties to add (or update).</param>
+        internal static PropertiesDictionary SetProperties(this PropertiesDictionary properties, IEnumerable<KeyValuePair<string, object?>> keyValuePairs)
+        {
+            foreach (var pair in keyValuePairs)
+                properties[pair.Key] = pair.Value;
+
+            return properties;
+        }
+
+        /// <summary>
+        /// Return the <see cref="PropertiesDictionary"/> as an enumerable of key-value pairs.
+        /// </summary>
+        /// <param name="properties">The properties which should by returned as key-value pairs.</param>
+        /// <returns>The properties as key-value pairs.</returns>
+        internal static IEnumerable<KeyValuePair<string, object?>> AsEnumerable(this ReadOnlyPropertiesDictionary properties)
+            => properties
+                .Cast<DictionaryEntry>()
+                .Select(property => Properties.CreateProperty((string)property.Key, property.Value));
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal static ReadOnlyPropertiesDictionary AsReadOnly(this PropertiesDictionary properties)
+            => properties;
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal static ActorPath? GetActorPath(this ReadOnlyPropertiesDictionary properties)
+            => (ActorPath?)properties[Properties.ActorPath];
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal static void SetActorPath(this PropertiesDictionary properties, ActorPath actorPath)
+            => properties[Properties.ActorPath] = actorPath;
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal static string? GetLogSource(this ReadOnlyPropertiesDictionary properties)
+            => (string?)properties[Properties.LogSource];
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal static void SetLogSource(this PropertiesDictionary properties, string logSource)
+            => properties[Properties.LogSource] = logSource;
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal static string? GetDeclaringTypeName(this ReadOnlyPropertiesDictionary properties)
+            => (string?)properties[Properties.DeclaringTypeName];
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal static void SetDeclaringTypeName(this PropertiesDictionary properties, Type declaringType)
+            => properties[Properties.DeclaringTypeName] = declaringType.FullName;
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal static string? GetMethodName(this ReadOnlyPropertiesDictionary properties)
+            => (string?)properties[Properties.MethodName];
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal static void SetMethodName(this PropertiesDictionary properties, string methodName)
+            => properties[Properties.MethodName] = methodName;
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal static string? GetFileName(this ReadOnlyPropertiesDictionary properties)
+            => (string?)properties[Properties.FileName];
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal static void SetFileName(this PropertiesDictionary properties, string fileName)
+            => properties[Properties.FileName] = fileName;
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal static string? GetLineNumber(this ReadOnlyPropertiesDictionary properties)
+            => properties[Properties.LineNumber] is int lineNumber
+                ? lineNumber.ToString(NumberFormatInfo.InvariantInfo)
+                : null;
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal static void SetLineNumber(this PropertiesDictionary properties, int lineNumber)
+            => properties[Properties.LineNumber] = lineNumber;
+    }
+}

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -4,15 +4,18 @@
   </PropertyGroup>
   <!-- Akka.NET Package Versions -->
   <ItemGroup>
-    <PackageVersion Include="Akka" Version="1.5.25"/>
+    <PackageVersion Include="Akka" Version="1.5.25" />
     <PackageVersion Include="log4net" Version="2.0.17" />
+    <PackageVersion Include="NSubstitute" Version="5.1.0" />
+    <PackageVersion Include="NSubstitute.Analyzers.CSharp" Version="1.0.17" />
     <PackageVersion Include="NuGet.Frameworks" Version="6.9.1" />
   </ItemGroup>
   <!-- Testing Utilities -->
   <ItemGroup>
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
-    <PackageVersion Include="xunit" Version="2.7.0" />
-    <PackageVersion Include="xunit.runner.visualstudio" Version="2.5.7" />
+    <PackageVersion Include="Akka.TestKit.Xunit2" Version="1.5.25" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
+    <PackageVersion Include="xunit" Version="2.8.1" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="2.8.1" />
     <PackageVersion Include="FluentAssertions" Version="6.12.0" />
     <PackageVersion Include="coverlet.collector" Version="6.0.2" />
   </ItemGroup>


### PR DESCRIPTION
Fixes #23

## Changes

This pull request introduces several enhancements and bug fixes for the `Akka.Logger.log4net` module. The key changes include:

- **Addition of Context Properties**: New methods in the Log4NetLoggingAdapter class allow for capturing and logging context properties such as source file name, line number, method name, and its declaring class. Additionally, user-defined custom context properties can be added and logged as well. This enriches the log entries with detailed context information, making it easier to trace and debug issues.

- **New Unit Tests**: Comprehensive unit tests have been added to verify the functionality of the new context properties methods. These tests ensure that the context properties are correctly captured and included in the log entries.

- **Documentation Updates**: The documentation has been updated to demonstrate how to use the new logging capabilities. Examples are provided to show how to log messages with custom properties and how to configure log4net to include these properties in the logs.

- **Release Notes**: Fixed a typo in `RELEASE_NOTES.md` to correct the release year from 2025 to 2024.

## Checklist

For significant changes, please ensure that the following have been completed (delete if not relevant):

* [ ] This change follows the [Akka.NET API Compatibility Guidelines](https://getakka.net/community/contributing/api-changes-compatibility.html).
* [x] This change follows the [Akka.NET Wire Compatibility Guidelines](https://getakka.net/community/contributing/wire-compatibility.html).
* [x] I have [reviewed my own pull request](https://getakka.net/community/contributing/index.html#review-your-own-pull-requests).
* [ ] Design discussion issue #
* [x] Changes in public API reviewed, if any.
* [x] I have added website documentation for this feature.

### Latest `dev` Benchmarks 

n/a

### This PR's Benchmarks

n/a