### PR TITLE
Bump AkkaVersion to 1.5.60

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -4,7 +4,7 @@
   </PropertyGroup>
   <!-- Akka.NET Package Versions -->
   <ItemGroup>
-    <PackageVersion Include="Akka" Version="1.5.25" />
+    <PackageVersion Include="Akka" Version="1.5.60" />
     <PackageVersion Include="log4net" Version="2.0.17" />
     <PackageVersion Include="NSubstitute" Version="5.1.0" />
     <PackageVersion Include="NSubstitute.Analyzers.CSharp" Version="1.0.17" />
@@ -12,7 +12,7 @@
   </ItemGroup>
   <!-- Testing Utilities -->
   <ItemGroup>
-    <PackageVersion Include="Akka.TestKit.Xunit2" Version="1.5.25" />
+    <PackageVersion Include="Akka.TestKit.Xunit2" Version="1.5.60" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
     <PackageVersion Include="xunit" Version="2.8.1" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="2.8.1" />


### PR DESCRIPTION
## Summary
- Updates Akka.NET dependency from 1.5.25 to 1.5.60
- Updates Akka.TestKit.Xunit2 dependency from 1.5.25 to 1.5.60

## Test Plan
- ✅ All 34 tests pass on .NET Framework 4.7.2
- ✅ Solution builds successfully