### PR TITLE
Add Akka.Hosting integration demo + integration tests

### DIFF
--- a/src/Akka.Logger.log4net.Tests.Hosting/Akka.Logger.log4net.Tests.Hosting.csproj
+++ b/src/Akka.Logger.log4net.Tests.Hosting/Akka.Logger.log4net.Tests.Hosting.csproj
@@ -1,0 +1,31 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <OutputType>Library</OutputType>
+    <IsPackable>false</IsPackable>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Akka.Hosting" />
+    <PackageReference Include="FluentAssertions" />
+    <PackageReference Include="log4net" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" />
+    <PackageReference Include="Microsoft.Extensions.Logging" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Akka.Logger.log4net\Akka.Logger.log4net.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/Akka.Logger.log4net.Tests.Hosting/Log4NetHostingIntegrationSpecs.cs
+++ b/src/Akka.Logger.log4net.Tests.Hosting/Log4NetHostingIntegrationSpecs.cs
@@ -1,0 +1,191 @@
+// Integration tests that prove Akka.Hosting correctly wires log4net as the
+// Akka logger and that log events actually travel through the adapter into
+// a log4net MemoryAppender.
+
+using Akka.Actor;
+using Akka.Event;
+using Akka.Hosting;
+using FluentAssertions;
+using log4net;
+using log4net.Appender;
+using log4net.Config;
+using log4net.Repository.Hierarchy;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+// Explicit alias to avoid ambiguity with Microsoft.Extensions.Logging.LogLevel
+using AkkaLogLevel = Akka.Event.LogLevel;
+
+namespace Akka.Logger.log4net.Tests.Hosting;
+
+/// <summary>
+/// End-to-end test: boot an ActorSystem via Akka.Hosting with
+/// AddLogger&lt;Log4NetLogger&gt;() and verify that log events emitted by the
+/// Akka logging infrastructure actually reach a log4net MemoryAppender.
+/// </summary>
+/// <remarks>
+/// Log4NetLogger calls LogManager.GetLogger(logEvent.LogClass) which resolves
+/// to the default log4net repository.  The MemoryAppender must therefore be
+/// attached to the default repository's root logger, not a named one.
+/// </remarks>
+public sealed class Log4NetHostingIntegrationSpecs : IAsyncLifetime
+{
+    private IHost? _host;
+    private MemoryAppender? _memoryAppender;
+    private Hierarchy? _hierarchy;
+
+    public async Task InitializeAsync()
+    {
+        // Attach a MemoryAppender to the DEFAULT log4net repository root
+        // because Log4NetLogger routes events through LogManager.GetLogger()
+        // which resolves to the default repository.
+        _hierarchy = (Hierarchy)LogManager.GetRepository();
+        _hierarchy.Root.Level = global::log4net.Core.Level.Debug;
+
+        _memoryAppender = new MemoryAppender();
+        _memoryAppender.ActivateOptions();
+
+        // Add the appender to the root logger of the default repository.
+        _hierarchy.Root.AddAppender(_memoryAppender);
+        _hierarchy.Configured = true;
+
+        _host = Host.CreateDefaultBuilder()
+            .ConfigureLogging(lb => lb.ClearProviders())
+            .ConfigureServices((_, services) =>
+            {
+                services.AddAkka("TestSystem", cb =>
+                {
+                    cb.ConfigureLoggers(lc =>
+                    {
+                        lc.ClearLoggers();
+                        lc.AddLogger<Log4NetLogger>();
+                        lc.LogLevel = AkkaLogLevel.DebugLevel;
+                    });
+                });
+            })
+            .Build();
+
+        await _host.StartAsync();
+    }
+
+    public async Task DisposeAsync()
+    {
+        if (_host is not null)
+        {
+            await _host.StopAsync();
+            _host.Dispose();
+        }
+
+        // Remove the MemoryAppender to avoid polluting other tests.
+        if (_memoryAppender is not null && _hierarchy is not null)
+        {
+            _hierarchy.Root.RemoveAppender(_memoryAppender);
+            _memoryAppender.Clear();
+        }
+    }
+
+    [Fact]
+    public async Task AddLogger_Log4NetLogger_routes_Akka_log_events_through_log4net()
+    {
+        // Arrange: obtain the ActorSystem from DI and emit a log message.
+        var actorSystem = _host!.Services.GetRequiredService<ActorSystem>();
+
+        const string expectedMessage = "Hosting integration test message from Akka";
+
+        var logger = Logging.GetLogger(actorSystem.EventStream, typeof(Log4NetHostingIntegrationSpecs).FullName!);
+
+        // Act: publish a log event into the Akka event stream.
+        // ILoggingAdapter in Akka 1.5.x exposes Log(LogLevel, Exception?, string)
+        // as its core interface method.
+        logger.Log(AkkaLogLevel.InfoLevel, null, expectedMessage);
+
+        // The Akka logger pipeline is asynchronous: the event travels from the
+        // caller -> EventStream -> Log4NetLogger actor mailbox -> log4net.
+        // Poll the MemoryAppender for up to 5 seconds to allow delivery.
+        global::log4net.Core.LoggingEvent[]? capturedEvents = null;
+        var deadline = DateTime.UtcNow.AddSeconds(5);
+
+        while (DateTime.UtcNow < deadline)
+        {
+            capturedEvents = _memoryAppender!.GetEvents();
+            if (capturedEvents.Any(e => e.RenderedMessage.Contains(expectedMessage)))
+                break;
+
+            await Task.Delay(50);
+        }
+
+        capturedEvents = _memoryAppender!.GetEvents();
+
+        // Assert: at least one event was captured and it contains our message.
+        capturedEvents.Should().NotBeNullOrEmpty(
+            "the Log4NetLogger actor should have forwarded the Akka log event to log4net");
+
+        capturedEvents!.Should().Contain(
+            e => e.RenderedMessage.Contains(expectedMessage),
+            $"the captured events should include the message '{expectedMessage}'");
+    }
+
+    [Fact]
+    public async Task AddLogger_Log4NetLogger_captures_warning_level_events()
+    {
+        var actorSystem = _host!.Services.GetRequiredService<ActorSystem>();
+
+        const string warningMessage = "This is a warning from Akka via log4net hosting integration";
+
+        var logger = Logging.GetLogger(actorSystem.EventStream, typeof(Log4NetHostingIntegrationSpecs).FullName!);
+        logger.Log(AkkaLogLevel.WarningLevel, null, warningMessage);
+
+        global::log4net.Core.LoggingEvent[]? events = null;
+        var deadline = DateTime.UtcNow.AddSeconds(5);
+
+        while (DateTime.UtcNow < deadline)
+        {
+            events = _memoryAppender!.GetEvents();
+            if (events.Any(e => e.Level == global::log4net.Core.Level.Warn &&
+                                e.RenderedMessage.Contains(warningMessage)))
+                break;
+
+            await Task.Delay(50);
+        }
+
+        events = _memoryAppender!.GetEvents();
+
+        events.Should().Contain(
+            e => e.Level == global::log4net.Core.Level.Warn &&
+                 e.RenderedMessage.Contains(warningMessage),
+            "warning-level Akka events should be routed as log4net Warn events");
+    }
+
+    [Fact]
+    public async Task AddLogger_Log4NetLogger_captures_error_level_events()
+    {
+        var actorSystem = _host!.Services.GetRequiredService<ActorSystem>();
+
+        const string errorMessage = "This is an error from Akka via log4net hosting integration";
+
+        var logger = Logging.GetLogger(actorSystem.EventStream, typeof(Log4NetHostingIntegrationSpecs).FullName!);
+        logger.Log(AkkaLogLevel.ErrorLevel, null, errorMessage);
+
+        global::log4net.Core.LoggingEvent[]? events = null;
+        var deadline = DateTime.UtcNow.AddSeconds(5);
+
+        while (DateTime.UtcNow < deadline)
+        {
+            events = _memoryAppender!.GetEvents();
+            if (events.Any(e => e.Level == global::log4net.Core.Level.Error &&
+                                e.RenderedMessage.Contains(errorMessage)))
+                break;
+
+            await Task.Delay(50);
+        }
+
+        events = _memoryAppender!.GetEvents();
+
+        events.Should().Contain(
+            e => e.Level == global::log4net.Core.Level.Error &&
+                 e.RenderedMessage.Contains(errorMessage),
+            "error-level Akka events should be routed as log4net Error events");
+    }
+}

--- a/src/Akka.Logger.log4net.sln
+++ b/src/Akka.Logger.log4net.sln
@@ -34,6 +34,12 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "scripts", "scripts", "{7343
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Akka.Logger.log4net.Tests", "Akka.Logger.log4net.Tests\Akka.Logger.log4net.Tests.csproj", "{F2BC0EB5-17AF-46A3-B0A9-935B1803504F}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "examples", "examples", "{A1B2C3D4-E5F6-7890-ABCD-EF1234567890}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Akka.Logger.log4net.HostingDemo", "Examples\Akka.Logger.log4net.HostingDemo\Akka.Logger.log4net.HostingDemo.csproj", "{B2C3D4E5-F6A7-8901-BCDE-F12345678901}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Akka.Logger.log4net.Tests.Hosting", "Akka.Logger.log4net.Tests.Hosting\Akka.Logger.log4net.Tests.Hosting.csproj", "{C3D4E5F6-A7B8-9012-CDEF-123456789012}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -48,6 +54,14 @@ Global
 		{F2BC0EB5-17AF-46A3-B0A9-935B1803504F}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{F2BC0EB5-17AF-46A3-B0A9-935B1803504F}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{F2BC0EB5-17AF-46A3-B0A9-935B1803504F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B2C3D4E5-F6A7-8901-BCDE-F12345678901}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B2C3D4E5-F6A7-8901-BCDE-F12345678901}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B2C3D4E5-F6A7-8901-BCDE-F12345678901}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B2C3D4E5-F6A7-8901-BCDE-F12345678901}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C3D4E5F6-A7B8-9012-CDEF-123456789012}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C3D4E5F6-A7B8-9012-CDEF-123456789012}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C3D4E5F6-A7B8-9012-CDEF-123456789012}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C3D4E5F6-A7B8-9012-CDEF-123456789012}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -56,6 +70,7 @@ Global
 		{D27357E5-702C-4E85-95A1-969FDCF765A6} = {828A76CC-8178-4470-B20B-DA78673D91C4}
 		{7AD6435A-870C-4D7D-859D-9FF1C5C72C58} = {D27357E5-702C-4E85-95A1-969FDCF765A6}
 		{73437FA7-88B8-4F5E-95B4-EF09F65AF87E} = {828A76CC-8178-4470-B20B-DA78673D91C4}
+		{B2C3D4E5-F6A7-8901-BCDE-F12345678901} = {A1B2C3D4-E5F6-7890-ABCD-EF1234567890}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {F927F8DD-8EEC-49AB-BDD2-EC7CE44C3FF9}

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -5,7 +5,10 @@
   <!-- Akka.NET Package Versions -->
   <ItemGroup>
     <PackageVersion Include="Akka" Version="1.5.60" />
+    <PackageVersion Include="Akka.Hosting" Version="1.5.60" />
     <PackageVersion Include="log4net" Version="2.0.17" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="8.0.1" />
+    <PackageVersion Include="Microsoft.Extensions.Logging" Version="8.0.1" />
     <PackageVersion Include="NSubstitute" Version="5.1.0" />
     <PackageVersion Include="NSubstitute.Analyzers.CSharp" Version="1.0.17" />
     <PackageVersion Include="NuGet.Frameworks" Version="6.9.1" />

--- a/src/Examples/Akka.Logger.log4net.HostingDemo/Akka.Logger.log4net.HostingDemo.csproj
+++ b/src/Examples/Akka.Logger.log4net.HostingDemo/Akka.Logger.log4net.HostingDemo.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <IsPublishable>false</IsPublishable>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Akka.Hosting" />
+    <PackageReference Include="log4net" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\Akka.Logger.log4net\Akka.Logger.log4net.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/Examples/Akka.Logger.log4net.HostingDemo/Program.cs
+++ b/src/Examples/Akka.Logger.log4net.HostingDemo/Program.cs
@@ -1,0 +1,89 @@
+// Akka.Logger.log4net Hosting Demo
+// Demonstrates wiring log4net as the Akka.NET logger via Akka.Hosting.
+
+using Akka.Actor;
+using Akka.Hosting;
+using Akka.Logger.log4net;
+using log4net;
+using log4net.Appender;
+using log4net.Config;
+using log4net.Layout;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+// --- Configure log4net programmatically ---
+// Use a console appender with a pattern that shows the Akka log source.
+var layout = new PatternLayout(
+    "%date{HH:mm:ss.fff} [%-5level] [%property{akka.logSource}] %message%newline%exception");
+layout.ActivateOptions();
+
+var consoleAppender = new ConsoleAppender { Layout = layout };
+consoleAppender.ActivateOptions();
+
+BasicConfigurator.Configure(consoleAppender);
+
+// Set the root logger to DEBUG so all Akka log events come through.
+var root = ((log4net.Repository.Hierarchy.Hierarchy)LogManager.GetRepository()).Root;
+root.Level = log4net.Core.Level.Debug;
+root.Repository.Configured = true;
+
+// --- Build and run the hosted application ---
+var host = Host.CreateDefaultBuilder(args)
+    // Silence Microsoft's generic host console output so only log4net lines appear.
+    .ConfigureLogging(lb => lb.ClearProviders())
+    .ConfigureServices((_, services) =>
+    {
+        services.AddAkka("DemoSystem", cb =>
+        {
+            cb.ConfigureLoggers(lc =>
+            {
+                // Remove the default Akka console logger and route all
+                // Akka log events through log4net instead.
+                lc.ClearLoggers();
+                lc.AddLogger<Log4NetLogger>();
+                // Use the fully-qualified Akka LogLevel to avoid ambiguity
+                // with Microsoft.Extensions.Logging.LogLevel.
+                lc.LogLevel = Akka.Event.LogLevel.DebugLevel;
+            });
+
+            // Register a simple actor that emits log messages on startup.
+            cb.WithActors((system, registry) =>
+            {
+                system.ActorOf(Props.Create(() => new DemoActor()), "demo");
+            });
+        });
+    })
+    .Build();
+
+await host.StartAsync();
+
+// Give the demo actor a moment to log its messages through the async pipeline.
+await Task.Delay(1500);
+
+await host.StopAsync();
+
+// --- Demo actor ---
+// ILoggingAdapter in Akka 1.5.x exposes Log(LogLevel, Exception?, string) as
+// its primary logging method on the interface. Use fully-qualified names to
+// avoid ambiguity with Microsoft.Extensions.Logging.LogLevel.
+public sealed class DemoActor : ReceiveActor
+{
+    private readonly Akka.Event.ILoggingAdapter _log = Akka.Event.Logging.GetLogger(
+        Context.System.EventStream, typeof(DemoActor).FullName!);
+
+    public DemoActor()
+    {
+        _log.Log(Akka.Event.LogLevel.InfoLevel, null,
+            "DemoActor started - log4net integration is working via Akka.Hosting.");
+
+        _log.Log(Akka.Event.LogLevel.DebugLevel, null,
+            $"Debug message: actor path is {Self.Path}");
+
+        _log.Log(Akka.Event.LogLevel.WarningLevel, null,
+            "Warning example: parameterized message Name=log4net Count=42");
+
+        _log.Log(Akka.Event.LogLevel.ErrorLevel, null,
+            "Error example: demonstrating error-level routing through the log4net adapter.");
+    }
+}


### PR DESCRIPTION
## Summary
Adds a runnable Akka.Hosting integration demo and automated integration tests for the log4net logger adapter. There was previously no Akka.Hosting example or validation in this repo.

## What's added
- `src/Examples/Akka.Logger.log4net.HostingDemo` — console app wiring log4net through `Akka.Hosting` (`ConfigureLoggers` → `ClearLoggers()` + `AddLogger<Log4NetLogger>()`)
- `src/Akka.Logger.log4net.Tests.Hosting` — 3 integration tests that boot an `ActorSystem` via `Akka.Hosting`, emit Akka log events, and assert a log4net `MemoryAppender` captured them
- `Akka.Hosting` 1.5.60 added to `Directory.Packages.props` (matches the repo's Akka 1.5.60)

## Validation
`dotnet test --framework net8.0` → 3/3 new integration tests passing. The example app runs and routes Akka log events through log4net.

README documentation for the Akka.Hosting setup will follow in a separate PR.