### PR TITLE
Upgrade to Akka.NET 1.5.69

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -4,18 +4,18 @@
   </PropertyGroup>
   <!-- Akka.NET Package Versions -->
   <ItemGroup>
-    <PackageVersion Include="Akka" Version="1.5.60" />
-    <PackageVersion Include="Akka.Hosting" Version="1.5.60" />
+    <PackageVersion Include="Akka" Version="1.5.69" />
+    <PackageVersion Include="Akka.Hosting" Version="1.5.69" />
     <PackageVersion Include="log4net" Version="2.0.17" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="8.0.1" />
-    <PackageVersion Include="Microsoft.Extensions.Logging" Version="8.0.1" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="9.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Logging" Version="9.0.0" />
     <PackageVersion Include="NSubstitute" Version="5.1.0" />
     <PackageVersion Include="NSubstitute.Analyzers.CSharp" Version="1.0.17" />
     <PackageVersion Include="NuGet.Frameworks" Version="6.9.1" />
   </ItemGroup>
   <!-- Testing Utilities -->
   <ItemGroup>
-    <PackageVersion Include="Akka.TestKit.Xunit2" Version="1.5.60" />
+    <PackageVersion Include="Akka.TestKit.Xunit2" Version="1.5.69" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
     <PackageVersion Include="xunit" Version="2.8.1" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="2.8.1" />


### PR DESCRIPTION
Bumps Akka, Akka.Hosting, and Akka.TestKit.Xunit2 to 1.5.69 (latest). Also bumps Microsoft.Extensions.Hosting and Microsoft.Extensions.Logging to 9.0.0 to satisfy the transitive dependency from Akka.Hosting 1.5.69 → OpenTelemetry 1.10.0 → Microsoft.Extensions.Logging >= 9.0.0. Build + net8.0 tests green (3/3 passed).