### PR TITLE
1.5.69 release notes

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,9 @@
+#### 1.5.69 June 16 2026 ####
+
+* Upgraded to [Akka.NET v1.5.69](https://github.com/akkadotnet/akka.net/releases/tag/1.5.69) ([#40](https://github.com/akkadotnet/Akka.Logger.log4net/pull/40))
+* Added Akka.Hosting integration demo project and automated integration tests for the log4net logger ([#38](https://github.com/akkadotnet/Akka.Logger.log4net/pull/38))
+* Updated README with documentation for configuring the log4net logger via Akka.Hosting ([#39](https://github.com/akkadotnet/Akka.Logger.log4net/pull/39))
+
 #### 1.5.25 June 19 2024 ####
 
 * Support for [Akka.NET v1.5.25](https://github.com/akkadotnet/akka.net/releases/tag/1.5.25)

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -2,10 +2,10 @@
   <PropertyGroup>
     <Copyright>Copyright © 2013-2024 Akka.NET Project</Copyright>
     <NoWarn>$(NoWarn);CS1591;NU1701;CA1707;</NoWarn>
-    <VersionPrefix>1.3.1</VersionPrefix>
+    <VersionPrefix>1.5.69</VersionPrefix>
     <Authors>Akka.NET Team</Authors>
     <PackageProjectUrl>https://github.com/akkadotnet/Akka.Logger.log4net</PackageProjectUrl>
-    <PackageReleaseNotes>Support for Akka 1.3.1</PackageReleaseNotes>
+    <PackageReleaseNotes>Upgraded to Akka.NET v1.5.69; added Akka.Hosting integration demo and docs</PackageReleaseNotes>
     <PackageTags>akka;actors;actor model;Akka;concurrency;log4net</PackageTags>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -5,7 +5,9 @@
     <VersionPrefix>1.5.69</VersionPrefix>
     <Authors>Akka.NET Team</Authors>
     <PackageProjectUrl>https://github.com/akkadotnet/Akka.Logger.log4net</PackageProjectUrl>
-    <PackageReleaseNotes>Upgraded to Akka.NET v1.5.69; added Akka.Hosting integration demo and docs</PackageReleaseNotes>
+    <PackageReleaseNotes>* Upgraded to [Akka.NET v1.5.69](https://github.com/akkadotnet/akka.net/releases/tag/1.5.69) ([#40](https://github.com/akkadotnet/Akka.Logger.log4net/pull/40))
+* Added Akka.Hosting integration demo project and automated integration tests for the log4net logger ([#38](https://github.com/akkadotnet/Akka.Logger.log4net/pull/38))
+* Updated README with documentation for configuring the log4net logger via Akka.Hosting ([#39](https://github.com/akkadotnet/Akka.Logger.log4net/pull/39))</PackageReleaseNotes>
     <PackageTags>akka;actors;actor model;Akka;concurrency;log4net</PackageTags>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>


### PR DESCRIPTION
## Summary

Draft RELEASE_NOTES for 1.5.69 (Akka.NET 1.5.69 upgrade + Akka.Hosting integration demo & docs). For maintainer review before release/publish.

## Changes included

- Upgraded to Akka.NET v1.5.69 ([#40](https://github.com/akkadotnet/Akka.Logger.log4net/pull/40))
- Added Akka.Hosting integration demo project and automated integration tests ([#38](https://github.com/akkadotnet/Akka.Logger.log4net/pull/38))
- Updated README with Akka.Hosting setup documentation ([#39](https://github.com/akkadotnet/Akka.Logger.log4net/pull/39))

## Files changed

- `RELEASE_NOTES.md` — prepended the 1.5.69 entry
- `src/Directory.Build.props` — bumped `VersionPrefix` from `1.3.1` to `1.5.69` (PR #40 updated `Directory.Packages.props` for Akka deps but did not bump this version property; `build.ps1` would set it at build time from RELEASE_NOTES.md, but it is set here explicitly so the committed file is correct without requiring the PowerShell script to run first)

**Do not merge without review. No auto-merge enabled. No tag or release created.**